### PR TITLE
クラスがあるキャラを表示した後に、ジョブアイコンがクラスのままになってしまう不具合を修正

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ class Profile extends React.Component {
   constructor(){
     super();
     this.state = {
-      lodestoneId: "22657106", // 22728375 / 
+      lodestoneId: "22657106", // 22728375
       characterData: {
         name: "キャラクター名",
         charaImgSrc: "",
@@ -82,18 +82,18 @@ class Profile extends React.Component {
           {jobName: "btn", JobID: 17, Level: "-", img: btn},
           {jobName: "fsh", JobID: 18, Level: "-", img: fsh},
         ],
-        class: [
-          {className: "gla", classID: 1,  img: gla},
-          {className: "mrd", classID: 3,  img: mrd},
-          {className: "cnj", classID: 6,  img: cnj},
-          {className: "pgl", classID: 2,  img: pgl},
-          {className: "lnc", classID: 4,  img: lnc},
-          {className: "rog", classID: 29, img: rog},
-          {className: "arc", classID: 5,  img: arc},
-          {className: "thm", classID: 7,  img: thm},
-          {className: "acn", classID: 26, img: acn},
-        ],
       },
+      class: [
+        {className: "gla", classID: 1,  img: gla},
+        {className: "mrd", classID: 3,  img: mrd},
+        {className: "cnj", classID: 6,  img: cnj},
+        {className: "pgl", classID: 2,  img: pgl},
+        {className: "lnc", classID: 4,  img: lnc},
+        {className: "rog", classID: 29, img: rog},
+        {className: "arc", classID: 5,  img: arc},
+        {className: "thm", classID: 7,  img: thm},
+        {className: "acn", classID: 26, img: acn},
+      ],
       isFirstLoading: true,
       isReloading: false,
     };
@@ -114,8 +114,8 @@ class Profile extends React.Component {
 
   setCharacterData(data) {
     const ClassJobs = data.Character.ClassJobs;
-    const currentJobs = this.state.characterData.job;
-    const currentClass = this.state.characterData.class;
+    const currentJobs = this.state.characterData.job.slice(0, 29);
+    const currentClass = this.state.class;
 
     // Levelだけを更新した新しいJobデータ
     let nextJob = currentJobs.map((currentJob) => {
@@ -133,10 +133,9 @@ class Profile extends React.Component {
         imgSrc = targetClass.img;
       }
       return {
-        jobName: currentJob.jobName,
         JobID: currentJob.JobID,
         Level: targetJob.Level,
-        img: imgSrc
+        img: imgSrc,
       };
     });
 
@@ -144,7 +143,7 @@ class Profile extends React.Component {
       characterData: {
       name: data.Character.Name,
       charaImgSrc: data.Character.Portrait,
-      job: nextJob
+      job: currentJobs.concat([nextJob]),
       },
       isFirstLoading: false,
       isReloading: false,
@@ -178,7 +177,7 @@ class Profile extends React.Component {
             </div>
             <div className="job">
               <p>ジョブレベル</p>
-              <JobList job={this.state.characterData.job} />
+              <JobList job={this.state.characterData.job[29]} />
             </div>
           </>
         }


### PR DESCRIPTION
ジョブを開放してないキャラを表示した後に、ジョブを開放しているキャラを表示させようとした時、ジョブアイコンがクラスのままになってしまう不具合を修正しました。